### PR TITLE
Add parseUserMode function

### DIFF
--- a/utils/modes.js
+++ b/utils/modes.js
@@ -80,12 +80,12 @@ function isMode(mode) {
 * @func
 * @param {string} userhost - userhost of bot
 * @param {string} channel - Channel modes could be applied to
-* @param {array} modes - array of modes to be applied to/in the channel
+* @param {array} modes_ - array of modes to be applied to/in the channel
 * @return {object} - The compiled user modes
 */
 function compileModes(userhost, channel, modes_) {
-    const msg = Buffer.from(`:${userhost} MODE ${channel} \r\n`);
-    //const MSGLEN = 512 - msg.byteLength; // Calculates characters remaining (unused for now)
+    // const msg = Buffer.from(`:${userhost} MODE ${channel} \r\n`); // (Unused)
+    // const MSGLEN = 512 - msg.byteLength; // Calculates characters remaining (unused for now)
 
     let finalmodes = {};
 

--- a/utils/modes.js
+++ b/utils/modes.js
@@ -7,25 +7,29 @@ let modes = {
         w: 'See wallops',
         Z: 'Secure connection'
     },
-    channel: {
+    'channel-users': {
         a: 'Admin',
         b: 'Ban',
+        e: 'Ban exemption',
+        I: 'Invite exemption',
+        q: 'Quiet',
+        o: 'Operator',
+        v: 'Voice'
+    },
+    channel: {
         B: 'amsg restriction',
         c: 'resrict colour codes',
         C: 'CTCP restriction',
-        e: 'Ban exemption',
         f: 'Forward',
         F: 'Enable forwaring',
         g: 'Allow open inviting',
         i: 'Invite only',
-        I: 'Invite exemption',
         j: 'Join throttle',
         k: 'Password protected',
         l: 'Join limit',
         m: 'Moderated',
         n: 'Prevent external messages',
         p: 'Private',
-        q: 'Quiet',
         Q: 'Block forwarded users',
         r: 'Block unidentified users',
         s: 'Secret',

--- a/utils/modes.js
+++ b/utils/modes.js
@@ -65,6 +65,18 @@ function requiresParam(mode) {
     return requiresParams.includes(mode);
 }
 
+
+
+/**
+* @func
+* @param {string} mode
+* @return {bool}
+*/
+function isMode(mode) {
+    return allModes.includes(mode);
+}
+
+
 /**
 * @func
 * @param {string} userhost - userhost of bot
@@ -141,6 +153,7 @@ module.exports = {
     modes,
     requiresParams,
     requiresParam,
+    isMode,
     compileModes,
     parseUserMode
 };

--- a/utils/modes.js
+++ b/utils/modes.js
@@ -66,7 +66,6 @@ function requiresParam(mode) {
 }
 
 
-
 /**
 * @func
 * @param {string} mode
@@ -84,13 +83,13 @@ function isMode(mode) {
 * @param {array} modes - array of modes to be applied to/in the channel
 * @return {object} - The compiled user modes
 */
-function compileModes(userhost, channel, modes) {
-    const msg = Buffer.from(`:${userhost} MODE ${channel} \r\n`)
-    const MSGLEN = 512 - msg.byteLength; // Calculates characters remaining
+function compileModes(userhost, channel, modes_) {
+    const msg = Buffer.from(`:${userhost} MODE ${channel} \r\n`);
+    //const MSGLEN = 512 - msg.byteLength; // Calculates characters remaining (unused for now)
 
     let finalmodes = {};
 
-    for (let i of modes) {
+    for (let i of modes_) {
         let reference = i;
         let [mode, target] = reference.split(' '); // ['+o', 'foo']
         let operator;
@@ -119,7 +118,7 @@ function parseUserMode(args) {
     let current_mode = '';
     let modes_arr = [];
 
-    /* Iterate over each character of modes.
+    /* Iterate over each character of modes_.
      * current_mode represents each individual mode (ie +o)
      * current_mode is reset each time a mode is "completed"
      * A list of seperated modes is added to

--- a/utils/modes.js
+++ b/utils/modes.js
@@ -87,7 +87,7 @@ function compileModes(userhost, channel, modes) {
 /**
 * @func
 * @param {array} args  Array in the format [modes, user1, user2...]
-* @return {array}      Array in the format:
+* @return {array}      Array in the format: [[mode, user]...]
 */
 function parseUserMode(args) {
     let modes = args[0];

--- a/utils/modes.js
+++ b/utils/modes.js
@@ -46,6 +46,13 @@ let modes = {
     }
 };
 
+let allModes = [];
+
+for (let i of Object.values(modes)) {
+    // Compress all mods into one array
+    allModes = allModes.concat(Object.keys(i));
+}
+
 let requiresParams = ['b', 'e', 'f', 'I', 'j', 'k', 'l', 'q'];
 const possibleUserModes = ['e', 'I', 'b', 'q', 'o', 'v'];
 

--- a/utils/modes.js
+++ b/utils/modes.js
@@ -1,7 +1,3 @@
-
-/** TODO: Separate channel modes into actual channels modes
-* and modes that can be set on users in channels
-*/
 let modes = {
     umodes: {
         g: 'Ignore private messages from unidentified users',
@@ -11,29 +7,25 @@ let modes = {
         w: 'See wallops',
         Z: 'Secure connection'
     },
-    'channel-users': {
+    channel: {
         a: 'Admin',
         b: 'Ban',
-        e: 'Ban exemption',
-        I: 'Invite exemption',
-        q: 'Quiet',
-        o: 'Operator',
-        v: 'Voice'
-    },
-    channel: {
         B: 'amsg restriction',
         c: 'resrict colour codes',
         C: 'CTCP restriction',
+        e: 'Ban exemption',
         f: 'Forward',
         F: 'Enable forwaring',
         g: 'Allow open inviting',
         i: 'Invite only',
+        I: 'Invite exemption',
         j: 'Join throttle',
         k: 'Password protected',
         l: 'Join limit',
         m: 'Moderated',
         n: 'Prevent external messages',
         p: 'Private',
+        q: 'Quiet',
         Q: 'Block forwarded users',
         r: 'Block unidentified users',
         s: 'Secret',
@@ -50,63 +42,63 @@ let modes = {
     }
 };
 
-let allModes = [];
-
-for (let i of Object.values(modes)) {
-    // Compress all mods into one array
-    allModes = allModes.concat(Object.keys(i));
-}
-
 let requiresParams = ['b', 'e', 'f', 'I', 'j', 'k', 'l', 'q'];
+const possibleUserModes = ['e', 'I', 'b', 'q', 'o', 'v'];
 
 /**
 * @func
 * @param {string} mode
-* @return {bool}
+* @return {bool} - True if mode requires param
 */
 function requiresParam(mode) {
     return requiresParams.includes(mode);
 }
 
-
 /**
 * @func
-* @param {string} mode
-* @return {bool}
+* @param {array} args  Array in the format [modes, user1, user2...]
+* @return {array}      Array in the format:
 */
-function isMode(mode) {
-    return allModes.includes(mode);
-}
+function parseUserMode(args) {
+    let modes = args[0];
+    let users = args.slice(1);
 
-/**
-* @func
-* @param {string} userhost - userhost of bot
-* @param {string} channel - Channel modes could be applied to
-* @param {array} modes - array of modes to be applied to/in the channel
-*/
-function compileModes(userhost, channel, modes) {
-    const msg = Buffer.from(`:${userhost} MODE ${channel} \r\n`)
-    const MSGLEN = 512 - msg.byteLength; // Calculates characters remaining
+    let current_mode = '';
+    let modes_arr = [];
 
-    let finalmodes = {};
-
-    for (let i of modes) {
-        let reference = i;
-        let [mode, target] = reference.split(' '); // ['+o', 'foo']
-        let operator;
-
-        [operator, mode] = mode.split(''); // ['+', 'o'];
-
-        if (!isMode(mode)) continue; // We continue to the next mode
-
-        if (!Object.keys(finalmodes).includes(target)) finalmodes[target] = [];
-
-        finalmodes[target].push([operator, mode]);
+    /* Iterate over each character of modes.
+     * current_mode represents each individual mode (ie +o)
+     * current_mode is reset each time a mode is "completed"
+     * A list of seperated modes is added to
+     * modes_arr */
+    for(let mode of modes) {
+        if(mode === '+' || mode === '-') {
+            current_mode = mode;
+        }
+        else if(possibleUserModes.includes(mode)) {
+            modes_arr.push(current_mode + mode);
+        }
     }
+
+    /* Case with only 1 user */
+    if(users.length == 1) {
+        return [modes_arr.join(''), users[0]];
+    }
+
+    let returned = [];
+    let i = 0;
+
+    for(let user of users) {
+        returned.push([modes_arr[i], user]);
+        i++;
+    }
+
+    return returned;
 }
 
 module.exports = {
     modes,
     requiresParams,
-    requiresParam
+    requiresParam,
+    parseUserMode
 };

--- a/utils/modes.js
+++ b/utils/modes.js
@@ -113,7 +113,7 @@ function compileModes(userhost, channel, modes) {
 * @return {array}      Array in the format: [[mode, user]...]
 */
 function parseUserMode(args) {
-    let modes = args[0];
+    let modes_ = args[0];
     let users = args.slice(1);
 
     let current_mode = '';
@@ -124,24 +124,23 @@ function parseUserMode(args) {
      * current_mode is reset each time a mode is "completed"
      * A list of seperated modes is added to
      * modes_arr */
-    for(let mode of modes) {
-        if(mode === '+' || mode === '-') {
+    for (let mode of modes_) {
+        if (mode === '+' || mode === '-') {
             current_mode = mode;
-        }
-        else if(possibleUserModes.includes(mode)) {
+        } else if (possibleUserModes.includes(mode)) {
             modes_arr.push(current_mode + mode);
         }
     }
 
     /* Case with only 1 user */
-    if(users.length == 1) {
+    if (users.length === 1) {
         return [modes_arr.join(''), users[0]];
     }
 
     let returned = [];
     let i = 0;
 
-    for(let user of users) {
+    for (let user of users) {
         returned.push([modes_arr[i], user]);
         i++;
     }


### PR DESCRIPTION
Adds a parseUserMode, which separates modes for individual users. For example,
```javascript
parseUserMode(["+oo", "User1", "User2"]);
```
Returns this:
```javascript
[["+o", "User1"], ["+o", "User2"]]
```

Also handles multiple modes on one user, ie
```javascript
parseUserMode(["-o+b", "User1"]);
// ["-o+b", "User1"]  
// (Yeah not the most useful)
```